### PR TITLE
Add OCR dependencies and simple tests

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -1,3 +1,3 @@
 # Default configuration
-# Add project-specific settings here
-
+ocr:
+  language: eng

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+pytesseract
+pdf2image
+pillow
+pyyaml

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,22 @@
+import os
+import yaml
+import logging
+
+
+def load_config(path='config/config.yaml'):
+    """Load YAML configuration from the given path."""
+    with open(path, 'r') as f:
+        return yaml.safe_load(f) or {}
+
+
+def configure_logger(log_file='logs/error.log'):
+    """Return a logger that writes errors to the specified file."""
+    logger = logging.getLogger('assistant_codex')
+    logger.setLevel(logging.ERROR)
+    os.makedirs(os.path.dirname(log_file), exist_ok=True)
+    if not logger.handlers:
+        handler = logging.FileHandler(log_file)
+        formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+    return logger

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,10 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from src.utils import load_config
+
+
+def test_load_config():
+    config = load_config('config/config.yaml')
+    assert isinstance(config, dict)
+    assert config.get('ocr', {}).get('language') == 'eng'

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -1,0 +1,14 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from src.utils import configure_logger
+
+
+def test_error_logging(tmp_path):
+    log_file = tmp_path / 'error.log'
+    logger = configure_logger(str(log_file))
+    logger.error('failure')
+    logger.handlers[0].flush()
+    with open(log_file) as f:
+        data = f.read()
+    assert 'failure' in data


### PR DESCRIPTION
## Summary
- list OCR-related packages in `requirements.txt`
- implement a basic config loader and logger utility
- provide simple tests for configuration loading and error logging
- add example OCR setting in `config.yaml`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685370825f908330ba886edd71ba36c3