### PR TITLE
Add UI placeholder tests

### DIFF
--- a/tests/test_header.py
+++ b/tests/test_header.py
@@ -1,0 +1,9 @@
+import pytest
+
+header = pytest.importorskip('ui.components.header')
+
+def test_render_header_contains_header_tag():
+    html = header.render_header()
+    assert isinstance(html, str)
+    assert '<header' in html.lower()
+    assert '</header>' in html.lower()

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -1,0 +1,34 @@
+import importlib
+import runpy
+import pytest
+
+st = pytest.importorskip('streamlit')
+app = pytest.importorskip('streamlit_app')
+
+def test_tabs_and_command_palette(monkeypatch):
+    called = {'tabs': 0, 'palette': 0}
+
+    def fake_tabs(*args, **kwargs):
+        called['tabs'] += 1
+        class Dummy:
+            def __enter__(self):
+                return self
+            def __exit__(self, exc_type, exc, tb):
+                pass
+        return [Dummy()]
+
+    def fake_palette(*args, **kwargs):
+        called['palette'] += 1
+
+    monkeypatch.setattr(st, 'tabs', fake_tabs, raising=False)
+    if hasattr(st, 'command_palette'):
+        monkeypatch.setattr(st, 'command_palette', fake_palette, raising=False)
+
+    if hasattr(app, 'main'):
+        app.main()
+    else:
+        importlib.reload(app)
+
+    assert called['tabs'] > 0
+    if hasattr(st, 'command_palette'):
+        assert called['palette'] > 0


### PR DESCRIPTION
## Summary
- add test for `ui.components.header.render_header`
- add test skeleton for Streamlit UI

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853739d63f48330ba29cab93c4fcc6b