### PR TITLE
Add project-wide .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,103 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff
+instance/
+.webassets-cache
+
+# Scrapy stuff
+.scrapy
+
+# Sphinx documentation
+/docs/_build/
+
+# PyBuilder
+/target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+.profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+celerybeat.pid
+
+# dotenv
+.env
+.env.*
+
+# Virtualenv
+venv/
+ENV/
+env/
+
+# MyPy
+.mypy_cache/
+
+# Pytest
+.pytest_cache/
+
+# project directories
+logs/
+ocr_output/
+chroma_db/
+summaries/


### PR DESCRIPTION
## Summary
- ignore Python build artifacts and local environment files
- exclude runtime directories `logs/`, `ocr_output/`, `chroma_db/` and `summaries/`

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: `assert False` in `tests/test_header.py::test_render_header_contains_header_tag`)*

------
https://chatgpt.com/codex/tasks/task_e_685377c02e388330beb16c3b6bd5224d